### PR TITLE
feat: add basic auth with admin access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,47 @@
+import React, { useState } from 'react'
 import VectorStoreSupportTool from './components/VectorStoreSupportTool'
+import Login from './components/Login'
+import AdminPanel from './components/AdminPanel'
+
+interface User {
+  username: string
+  role: 'user' | 'admin'
+}
 
 export default function App() {
-  return <VectorStoreSupportTool />
+  const [user, setUser] = useState<User | null>(null)
+  const [showAdmin, setShowAdmin] = useState(false)
+
+  if (!user) {
+    return <Login onLogin={setUser} />
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between bg-gray-100 px-4 py-2 text-sm">
+        <span>
+          Logged in as {user.username} ({user.role})
+        </span>
+        <div className="space-x-2">
+          {user.role === 'admin' && (
+            <button
+              onClick={() => setShowAdmin((s) => !s)}
+              className="text-blue-600 hover:underline"
+            >
+              {showAdmin ? 'Close Admin' : 'Admin Panel'}
+            </button>
+          )}
+          <button onClick={() => setUser(null)} className="text-red-600 hover:underline">
+            Logout
+          </button>
+        </div>
+      </div>
+      {showAdmin && user.role === 'admin' ? (
+        <AdminPanel onBack={() => setShowAdmin(false)} />
+      ) : (
+        <VectorStoreSupportTool />
+      )}
+    </div>
+  )
 }
+

--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+interface AdminPanelProps {
+  onBack: () => void
+}
+
+export default function AdminPanel({ onBack }: AdminPanelProps) {
+  return (
+    <div className="p-6">
+      <h2 className="text-2xl font-semibold mb-4">Admin Panel</h2>
+      <p className="mb-6">Welcome, administrator. This area is restricted to admin users.</p>
+      <button
+        onClick={onBack}
+        className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-700"
+      >
+        Back to Tool
+      </button>
+    </div>
+  )
+}

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+
+interface LoginProps {
+  onLogin: (user: { username: string; role: 'user' | 'admin' }) => void
+}
+
+const USERS: Record<string, { password: string; role: 'user' | 'admin' }> = {
+  test: { password: 'test', role: 'user' },
+  admin: { password: 'admin', role: 'admin' }
+}
+
+export default function Login({ onLogin }: LoginProps) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault()
+    const u = USERS[username as keyof typeof USERS]
+    if (!u || u.password !== password) {
+      setError('Invalid credentials')
+      return
+    }
+    setError('')
+    onLogin({ username, role: u.role })
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded-xl shadow-md w-full max-w-sm">
+        <h2 className="text-xl font-semibold mb-4 text-center">Support Tool Login</h2>
+        <div className="mb-3">
+          <label className="block text-sm font-medium mb-1" htmlFor="username">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm font-medium mb-1" htmlFor="password">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+          />
+        </div>
+        {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-2 rounded-md text-sm hover:bg-blue-700"
+        >
+          Log In
+        </button>
+      </form>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add login flow with hard-coded test and admin users
- allow admin to view a simple admin panel and toggle back to tool
- show user info bar with logout and admin panel controls

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8084e7e0833092af8f9869e673a5